### PR TITLE
Fixed two issues in device-position routes

### DIFF
--- a/app-backend/api/schema/rooms_schema.py
+++ b/app-backend/api/schema/rooms_schema.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel, ConfigDict
 
 class RoomBase(BaseModel):
@@ -6,7 +8,7 @@ class RoomBase(BaseModel):
     roomName: str
 
 class RoomPublic(RoomBase):
-    buildingId: int
+    buildingId: Optional[int] = None
     roomId:int
     
 class RoomLayout(RoomBase):

--- a/app-backend/api/services/devices.py
+++ b/app-backend/api/services/devices.py
@@ -61,7 +61,7 @@ def device_in_position(session: Session, roomId: int, posX: int, posY: int):
         Devices.positionY == posY
     )
 
-    hasDevice = session.exec(statement).one()
+    hasDevice = session.exec(statement).one_or_none()
 
     return hasDevice is not None
 


### PR DESCRIPTION
- Fixed an issue where the validation for Room schema would fail because buildingId was a null foreign key references.
        - Fixed by making the buildingId in the schema model optional too prevent the validation failure

- Fixed an issue where moving a device would fail because the service for moving devices would not return none.
    - Fixed by changing from .one() --> .one_or_none()